### PR TITLE
Do not add new decisions after close + catch exception if it was added

### DIFF
--- a/swiffer-api/pom.xml
+++ b/swiffer-api/pom.xml
@@ -9,6 +9,7 @@
 	<artifactId>swiffer-api</artifactId>
 	<properties>
 		<jackson.modules.version>2.6.1</jackson.modules.version>
+		<junitparams.version>0.9.0</junitparams.version>
 	</properties>
 	<dependencies>
 
@@ -69,6 +70,12 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-guava</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>pl.pragmatists</groupId>
+			<artifactId>JUnitParams</artifactId>
+			<scope>test</scope>
+			<version>${junitparams.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>info.cukes</groupId>

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/Decisions.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/Decisions.java
@@ -261,4 +261,9 @@ public interface Decisions {
 	 * @return this {@link Decisions} object
 	 */
 	Decisions requestCancelExternalWorkflow(String workflowId, String runId, Object control);
+
+	/**
+	 * @deprecated draft implementation
+	 */
+	Decisions continueAsNewWorkflow(String version);
 }

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/Decisions.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/Decisions.java
@@ -164,6 +164,16 @@ public interface Decisions {
 	 */
 	Decisions retryActivity(Long scheduledEventId, ActivityTaskFailedContext context);
 
+	/**
+	 * Automatically retries failed activity from {@link ActivityTaskFailedContext} with specified {@code retryPolicy}.
+	 *
+	 * @param scheduledEventId id of the ActivityTaskScheduled event that was recorded when activity task that failed was scheduled
+	 * @param context          the {@link DecisionTaskContext}
+	 * @param retryPolicy      one of the {@link RetryPolicy} which should be used to retry the activity
+	 * @return this {@link Decisions} object
+	 */
+	Decisions retryActivity(Long scheduledEventId, ActivityTaskFailedContext context, RetryPolicy retryPolicy);
+
     /**
      * Automatically retries failed activity {@code activityType} with specified {@code retryPolicy}.
      *

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/Swiffer.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/Swiffer.java
@@ -219,7 +219,7 @@ public class Swiffer {
 	 *             if the workflow designated by this workflowId is not open
 	 */
 	public void sendSignalToWorkflow(final String workflowId, final String signalName) {
-
+		doSignal(workflowId, signalName, null);
 	}
 
 	/**

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DeciderImpl.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DeciderImpl.java
@@ -3,6 +3,7 @@ package com.solambda.swiffer.api.internal.decisions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.amazonaws.services.simpleworkflow.model.AmazonSimpleWorkflowException;
 import com.amazonaws.services.simpleworkflow.model.UnknownResourceException;
 import com.solambda.swiffer.api.Decider;
 import com.solambda.swiffer.api.Decisions;
@@ -54,6 +55,15 @@ public class DeciderImpl extends AbstractTaskListService<DecisionTaskContext> im
 		} catch (UnknownResourceException ex) {
 			//TODO: add more sophisticated error handling?
 			LOGGER.error("Cannot make decisions based on the context  " + context, ex);
+		} catch (AmazonSimpleWorkflowException ex) {
+			switch (ex.getErrorType()) {
+				case Client:
+					LOGGER.error("SWF Client error for context " + context, ex);
+					break;
+				case Service:
+				case Unknown:
+					throw new IllegalStateException("Cannot make decisions based on the context  " + context, ex);
+			}
 		} catch (final Exception e) {
 			// how to recover from that ?
 			// use a marker for failure, and externally relaunch ?

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DecisionExecutorImpl.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DecisionExecutorImpl.java
@@ -1,17 +1,43 @@
 package com.solambda.swiffer.api.internal.decisions;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.model.Decision;
+import com.amazonaws.services.simpleworkflow.model.DecisionType;
 import com.amazonaws.services.simpleworkflow.model.RespondDecisionTaskCompletedRequest;
 import com.solambda.swiffer.api.Decisions;
 
 public class DecisionExecutorImpl implements DecisionExecutor {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DecisionExecutorImpl.class);
+
+	/**
+	 * List of decisions that close the workflow.
+	 */
+	private static final List<String> CLOSE_DECISIONS = Arrays.asList(DecisionType.CancelWorkflowExecution.name(),
+																	  DecisionType.CompleteWorkflowExecution.name(),
+																	  DecisionType.FailWorkflowExecution.name(),
+																	  DecisionType.ContinueAsNewWorkflowExecution.name());
+	/**
+	 * Evaluates if specified decision is the close workflow decision.
+	 */
+	private static final Predicate<Decision> isCloseDecision = d -> CLOSE_DECISIONS.contains(d.getDecisionType());
+
+	/**
+	 * List of decisions that could be added with close the workflow decision.
+	 */
+	private static final List<String> COMPATIBLE_WITH_CLOSE = Arrays.asList(DecisionType.CancelTimer.name(),
+																			DecisionType.RecordMarker.name(),
+																			DecisionType.StartChildWorkflowExecution.name(),
+																			DecisionType.RequestCancelExternalWorkflowExecution.name());
 
 	private AmazonSimpleWorkflow swf;
 
@@ -22,8 +48,11 @@ public class DecisionExecutorImpl implements DecisionExecutor {
 
 	@Override
 	public void apply(final DecisionTaskContext context, final Decisions decisions) {
-		final Collection<Decision> decisionList = ((DecisionsImpl) decisions).get();
+		LOGGER.debug("Receive {} decisions: {}", ((DecisionsImpl) decisions).get().size(), decisions);
+
+		final Collection<Decision> decisionList = normalize(((DecisionsImpl) decisions).get());
 		LOGGER.debug("Responding SWF with {} decisions: {}", decisionList.size(), decisions);
+
 		this.swf.respondDecisionTaskCompleted(new RespondDecisionTaskCompletedRequest()
 													  .withDecisions(decisionList)
 													  // FIXME: why and how to get it ? (appart from externally ?)
@@ -31,4 +60,25 @@ public class DecisionExecutorImpl implements DecisionExecutor {
 													  .withTaskToken(context.taskToken()));
 	}
 
+	/**
+	 * Filter list of received decisions leaving only ones that could be processed together.
+	 *
+	 * @param decisions list of decisions received after task processing
+	 * @return list of decisions which could be executed together without errors
+	 */
+	private Collection<Decision> normalize(Collection<Decision> decisions) {
+		if (decisions.stream().anyMatch(isCloseDecision)) {
+			return decisions.stream().filter(decision -> {
+				String decisionType = decision.getDecisionType();
+				if (COMPATIBLE_WITH_CLOSE.contains(decisionType) || CLOSE_DECISIONS.contains(decisionType)) {
+					return true;
+				} else {
+					LOGGER.warn("Close decision is incompatible with this decision, skip decision {}.", decision);
+					return false;
+				}
+			}).collect(Collectors.toList());
+		}
+
+		return new ArrayList<>(decisions);
+	}
 }

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DecisionsImpl.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DecisionsImpl.java
@@ -17,6 +17,7 @@ import com.solambda.swiffer.api.Decisions;
 import com.solambda.swiffer.api.WorkflowOptions;
 import com.solambda.swiffer.api.duration.DurationTransformer;
 import com.solambda.swiffer.api.internal.context.ActivityTaskFailedContext;
+import com.solambda.swiffer.api.internal.handler.CloseWorkflowControl;
 import com.solambda.swiffer.api.internal.utils.SWFUtils;
 import com.solambda.swiffer.api.mapper.DataMapper;
 import com.solambda.swiffer.api.retry.RetryControl;
@@ -40,7 +41,7 @@ public class DecisionsImpl implements Decisions {
 	/**
 	 * @return the list of decisions
 	 */
-	public Collection<Decision> get() {
+	public List<Decision> get() {
 		return Collections.unmodifiableList(this.decisions);
 	}
 
@@ -161,33 +162,22 @@ public class DecisionsImpl implements Decisions {
 
 	@Override
 	public Decisions completeWorkflow() {
-		return completeWorkflow(null);
+		return doCompleteWorkflow(null);
 	}
 
 	@Override
 	public Decisions completeWorkflow(final Object result) {
-		newDecision(DecisionType.CompleteWorkflowExecution)
-				.withCompleteWorkflowExecutionDecisionAttributes(
-						new CompleteWorkflowExecutionDecisionAttributes()
-								.withResult(serialize(result)));
-		return this;
+		return doCompleteWorkflow(result);
 	}
 
 	@Override
 	public Decisions cancelWorkflow(final String details) {
-		newDecision(DecisionType.CancelWorkflowExecution)
-				.withCancelWorkflowExecutionDecisionAttributes(new CancelWorkflowExecutionDecisionAttributes()
-																	   .withDetails(details));
-		return this;
+		return doCancelWorkflow(details);
 	}
 
 	@Override
 	public Decisions failWorkflow(final String reason, final String details) {
-		newDecision(DecisionType.FailWorkflowExecution)
-				.withFailWorkflowExecutionDecisionAttributes(new FailWorkflowExecutionDecisionAttributes()
-						.withReason(reason)
-						.withDetails(details));
-		return this;
+		return doFailWorkflow(reason, details);
 	}
 
 	@Override
@@ -216,16 +206,14 @@ public class DecisionsImpl implements Decisions {
 
 	@Override
     public Decisions recordMarker(String markerName, Object details) {
-        newDecision(DecisionType.RecordMarker)
-                .withRecordMarkerDecisionAttributes(new RecordMarkerDecisionAttributes()
-                                                            .withMarkerName(markerName)
-                                                            .withDetails(serialize(details)));
-        return this;
+		checkMarkerName(markerName);
+		return doRecordMarker(markerName, details);
     }
 
-    @Override
+	@Override
     public Decisions recordMarker(String markerName) {
-        return recordMarker(markerName, null);
+		checkMarkerName(markerName);
+        return doRecordMarker(markerName, null);
     }
 
 	@Override
@@ -324,6 +312,40 @@ public class DecisionsImpl implements Decisions {
 		return this;
 	}
 
+	private Decisions doRecordMarker(String markerName, Object details) {
+		newDecision(DecisionType.RecordMarker)
+				.withRecordMarkerDecisionAttributes(new RecordMarkerDecisionAttributes()
+															.withMarkerName(markerName)
+															.withDetails(serialize(details)));
+		return this;
+	}
+
+	private Decisions doCompleteWorkflow(Object result) {
+		doRecordMarker(CloseWorkflowControl.COMPLETE_MARKER, CloseWorkflowControl.completeWorkflowControl(result));
+		newDecision(DecisionType.CompleteWorkflowExecution)
+				.withCompleteWorkflowExecutionDecisionAttributes(
+						new CompleteWorkflowExecutionDecisionAttributes()
+								.withResult(serialize(result)));
+		return this;
+	}
+
+	private Decisions doCancelWorkflow(String details) {
+		doRecordMarker(CloseWorkflowControl.CANCEL_MARKER, CloseWorkflowControl.cancelWorkflowControl(details));
+		newDecision(DecisionType.CancelWorkflowExecution)
+				.withCancelWorkflowExecutionDecisionAttributes(new CancelWorkflowExecutionDecisionAttributes()
+																	   .withDetails(details));
+		return this;
+	}
+
+	private Decisions doFailWorkflow(String reason, String details) {
+		doRecordMarker(CloseWorkflowControl.FAIL_MARKER, CloseWorkflowControl.failWorkflowControl(reason, details));
+		newDecision(DecisionType.FailWorkflowExecution)
+				.withFailWorkflowExecutionDecisionAttributes(new FailWorkflowExecutionDecisionAttributes()
+																	 .withReason(reason)
+																	 .withDetails(details));
+		return this;
+	}
+
 	private Decisions doContinueAsNewWorkflow(Object input, WorkflowOptions options, Collection<String> tags, String version) {
 		// TODO: complete in Issue #11
 		WorkflowOptions params = SWFUtils.defaultIfNull(options, new WorkflowOptions());
@@ -344,5 +366,21 @@ public class DecisionsImpl implements Decisions {
 		newDecision(DecisionType.ContinueAsNewWorkflowExecution).withContinueAsNewWorkflowExecutionDecisionAttributes(attributes);
 
 		return this;
+	}
+
+	/**
+	 * Ensure custom handler can not be specified for internal timer.
+	 *
+	 * @param markerName timer ID
+	 * @return timer ID if acceptable
+	 * @throws IllegalArgumentException if selected timer name is reserved for internal use
+	 */
+	private static String checkMarkerName(String markerName) {
+		Preconditions.checkNotNull(markerName);
+		Preconditions.checkArgument(!SWFUtils.startsWithAny(markerName, CloseWorkflowControl.CANCEL_MARKER,
+															CloseWorkflowControl.COMPLETE_MARKER,
+															CloseWorkflowControl.FAIL_MARKER), "This is reserved marker name");
+
+		return markerName;
 	}
 }

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DecisionsImpl.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/DecisionsImpl.java
@@ -2,7 +2,6 @@ package com.solambda.swiffer.api.internal.decisions;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -25,14 +24,8 @@ import com.solambda.swiffer.api.retry.RetryPolicy;
 
 public class DecisionsImpl implements Decisions {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DecisionsImpl.class);
-	/**
-	 * List of decisions that should be the last decision in the list.
-	 */
-	private static final List<String> FINAL_DECISIONS = Arrays.asList(DecisionType.CancelWorkflowExecution.name(),
-																	  DecisionType.CompleteWorkflowExecution.name(),
-																	  DecisionType.FailWorkflowExecution.name(),
-																	  DecisionType.ContinueAsNewWorkflowExecution.name());
-	private final List<Decision> decisions;
+
+	private List<Decision> decisions;
 	private final DataMapper dataMapper;
 	private final DurationTransformer durationTransformer;
 	private final RetryPolicy globalRetryPolicy;
@@ -52,24 +45,15 @@ public class DecisionsImpl implements Decisions {
 	}
 
 	/**
-	 * Adds a new decision to the list of decisions for the given type,
-	 * and returns the decision to allow configuring it.
-	 * <p>
-	 * If the decision list contains decision to close workflow (either complete, cancel or fail),
-	 * then new decision will not be added to the list and subsequently will not be sent to the server.
-	 * But the valid decision still be returned by this method.
-	 * </p>
+	 * add a new decision to the list of deicisions for the given type, and
+	 * return the decision to allow configuring it
 	 *
-	 * @param decisionType new decision type
-	 * @return new {@link Decision}
+	 * @param decisionType
+	 * @return
 	 */
 	private Decision newDecision(final DecisionType decisionType) {
 		final Decision decision = new Decision().withDecisionType(decisionType);
-		if (decisions.stream().anyMatch(d -> FINAL_DECISIONS.contains(d.getDecisionType()))) {
-			LOGGER.warn("Decision list already has decision to close workflow, which should be the last decision in the list. Skipping new decision {}", decision);
-		} else {
-			this.decisions.add(decision);
-		}
+		this.decisions.add(decision);
 		return decision;
 	}
 

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/EventHandlerRegistry.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/EventHandlerRegistry.java
@@ -2,15 +2,27 @@ package com.solambda.swiffer.api.internal.decisions;
 
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.simpleworkflow.model.CancelWorkflowExecutionFailedCause;
+import com.amazonaws.services.simpleworkflow.model.CompleteWorkflowExecutionFailedCause;
+import com.amazonaws.services.simpleworkflow.model.ContinueAsNewWorkflowExecutionFailedCause;
+import com.amazonaws.services.simpleworkflow.model.FailWorkflowExecutionFailedCause;
 import com.solambda.swiffer.api.retry.RetryControl;
 
 public class EventHandlerRegistry {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventHandlerRegistry.class);
 
 	private final Map<EventHandlerType, EventHandler> eventHandlerRegistry;
 
 	private EventHandler defaultFailedActivityHandler;
     private EventHandler defaultTimedOutActivityHandler;
     private EventHandler defaultRetryTimerFiredHandler;
+    private EventHandler defaultCompleteWorkflowExecutionFailedHandler;
+    private EventHandler defaultCancelWorkflowExecutionFailedHandler;
+    private EventHandler defaultFailWorkflowExecutionFailedHandler;
+    private EventHandler defaultContinueAsNewWorkflowExecutionFailedHandler;
 
 	public EventHandlerRegistry(final Map<EventHandlerType, EventHandler> eventHandlerRegistry) {
 		super();
@@ -46,5 +58,73 @@ public class EventHandlerRegistry {
 
     void setDefaultRetryTimerFiredHandler(EventHandler defaultRetryTimerFiredHandler) {
         this.defaultRetryTimerFiredHandler = defaultRetryTimerFiredHandler;
+    }
+
+    EventHandler getDefaultCompleteWorkflowExecutionFailedHandler(String cause) {
+        try {
+            CompleteWorkflowExecutionFailedCause completeFailedCause = CompleteWorkflowExecutionFailedCause.fromValue(cause);
+            if (completeFailedCause == CompleteWorkflowExecutionFailedCause.UNHANDLED_DECISION) {
+                return defaultCompleteWorkflowExecutionFailedHandler;
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unable to create defaultCompleteWorkflowExecutionFailedHandler.", e);
+        }
+
+        return null;
+    }
+
+    void setDefaultCompleteWorkflowExecutionFailedHandler(EventHandler defaultCompleteWorkflowExecutionFailedHandler) {
+        this.defaultCompleteWorkflowExecutionFailedHandler = defaultCompleteWorkflowExecutionFailedHandler;
+    }
+
+    EventHandler getDefaultCancelWorkflowExecutionFailedHandler(String cause) {
+        try {
+            CancelWorkflowExecutionFailedCause cancelFailedCause = CancelWorkflowExecutionFailedCause.fromValue(cause);
+            if (cancelFailedCause == CancelWorkflowExecutionFailedCause.UNHANDLED_DECISION) {
+                return defaultCancelWorkflowExecutionFailedHandler;
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unable to create defaultCancelWorkflowExecutionFailedHandler.", e);
+        }
+
+        return null;
+    }
+
+    void setDefaultCancelWorkflowExecutionFailedHandler(EventHandler defaultCancelWorkflowExecutionFailedHandler) {
+        this.defaultCancelWorkflowExecutionFailedHandler = defaultCancelWorkflowExecutionFailedHandler;
+    }
+
+    EventHandler getDefaultFailWorkflowExecutionFailedHandler(String cause) {
+        try {
+            FailWorkflowExecutionFailedCause failFailedCause = FailWorkflowExecutionFailedCause.fromValue(cause);
+            if (failFailedCause == FailWorkflowExecutionFailedCause.UNHANDLED_DECISION) {
+                return defaultFailWorkflowExecutionFailedHandler;
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unable to create defaultFailWorkflowExecutionFailedHandler.", e);
+        }
+
+        return null;
+    }
+
+    void setDefaultFailWorkflowExecutionFailedHandler(EventHandler defaultFailWorkflowExecutionFailedHandler) {
+        this.defaultFailWorkflowExecutionFailedHandler = defaultFailWorkflowExecutionFailedHandler;
+    }
+
+    EventHandler getDefaultContinueAsNewWorkflowExecutionFailedHandler(String cause) {
+        try {
+            ContinueAsNewWorkflowExecutionFailedCause continueAsNewFailedCause = ContinueAsNewWorkflowExecutionFailedCause.fromValue(cause);
+            if (continueAsNewFailedCause == ContinueAsNewWorkflowExecutionFailedCause.UNHANDLED_DECISION) {
+                return defaultContinueAsNewWorkflowExecutionFailedHandler;
+            }
+        } catch (Exception e) {
+            LOGGER.error("Unable to create defaultContinueAsNewWorkflowExecutionFailedHandler.", e);
+        }
+
+        return null;
+    }
+
+    void setDefaultContinueAsNewWorkflowExecutionFailedHandler(EventHandler defaultContinueAsNewWorkflowExecutionFailedHandler) {
+        this.defaultContinueAsNewWorkflowExecutionFailedHandler = defaultContinueAsNewWorkflowExecutionFailedHandler;
     }
 }

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/EventHandlerRegistryFactory.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/EventHandlerRegistryFactory.java
@@ -26,6 +26,11 @@ public class EventHandlerRegistryFactory {
         eventHandlerRegistry.setDefaultTimedOutActivityHandler(factory.createTimedOutActivityHandler());
         eventHandlerRegistry.setDefaultRetryTimerFiredHandler(factory.createRetryTimerFiredHandler());
 
+		eventHandlerRegistry.setDefaultCancelWorkflowExecutionFailedHandler(factory.createCancelWorkflowExecutionFailedHandler());
+		eventHandlerRegistry.setDefaultCompleteWorkflowExecutionFailedHandler(factory.createCompleteWorkflowExecutionFailedHandler());
+		eventHandlerRegistry.setDefaultContinueAsNewWorkflowExecutionFailedHandler(factory.createContinueAsNewWorkflowExecutionFailedHandler());
+		eventHandlerRegistry.setDefaultFailWorkflowExecutionFailedHandler(factory.createFailWorkflowExecutionFailedHandler());
+
         return eventHandlerRegistry;
 	}
 

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/WorkflowTemplateImpl.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/decisions/WorkflowTemplateImpl.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.simpleworkflow.model.EventType;
 import com.solambda.swiffer.api.Decisions;
 import com.solambda.swiffer.api.duration.DurationTransformer;
 import com.solambda.swiffer.api.internal.VersionedName;
+import com.solambda.swiffer.api.internal.events.HasCause;
 import com.solambda.swiffer.api.internal.events.HasTimerId;
 import com.solambda.swiffer.api.mapper.DataMapper;
 import com.solambda.swiffer.api.retry.RetryPolicy;
@@ -91,6 +92,18 @@ public class WorkflowTemplateImpl implements WorkflowTemplate {
                 String timerId = ((HasTimerId) eventContext).timerId();
                 eventHandler = eventHandlerRegistry.getDefaultRetryTimerFiredHandler(timerId);
                 break;
+			case CompleteWorkflowExecutionFailed:
+				eventHandler = eventHandlerRegistry.getDefaultCompleteWorkflowExecutionFailedHandler(((HasCause)eventContext).cause());
+				break;
+			case CancelWorkflowExecutionFailed:
+				eventHandler = eventHandlerRegistry.getDefaultCancelWorkflowExecutionFailedHandler(((HasCause)eventContext).cause());
+				break;
+			case FailWorkflowExecutionFailed:
+				eventHandler = eventHandlerRegistry.getDefaultFailWorkflowExecutionFailedHandler(((HasCause)eventContext).cause());
+				break;
+			case ContinueAsNewWorkflowExecutionFailed:
+				eventHandler = eventHandlerRegistry.getDefaultContinueAsNewWorkflowExecutionFailedHandler(((HasCause)eventContext).cause());
+				break;
         }
         if (eventHandler != null) {
             eventHandler.handleEvent(eventContext, decisions);

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/handler/CloseWorkflowControl.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/handler/CloseWorkflowControl.java
@@ -1,0 +1,124 @@
+package com.solambda.swiffer.api.internal.handler;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import com.amazonaws.services.simpleworkflow.model.CancelWorkflowExecutionDecisionAttributes;
+import com.amazonaws.services.simpleworkflow.model.CompleteWorkflowExecutionDecisionAttributes;
+import com.amazonaws.services.simpleworkflow.model.DecisionType;
+import com.amazonaws.services.simpleworkflow.model.FailWorkflowExecutionDecisionAttributes;
+
+/**
+ * Control object which hold information about parameters for close workflow decisions.
+ * This information is needed to reschedule close decision in case in has failed.
+ * This object is recorded in specific marker and then fetched for retry
+ * (since there is no way to retrieve this information from avaliable workflow history or failed event information).
+ *
+ * @see CloseWorkflowFailedHandlers
+ */
+public class CloseWorkflowControl implements Serializable {
+    private static final long serialVersionUID = -32883342290518485L;
+
+    public static final String CANCEL_MARKER = "SWIFFER_CANCEL_MARKER";
+    public static final String COMPLETE_MARKER = "SWIFFER_COMPLETE_MARKER";
+    public static final String FAIL_MARKER = "SWIFFER_FAIL_MARKER";
+
+    private Object result;
+    private String reason;
+    private String details;
+
+    private CloseWorkflowControl() {
+    }
+
+    /**
+     * Creates control object with information for {@link DecisionType#CancelWorkflowExecution} decision.
+     *
+     * @param details details of the cancellation, optional
+     * @return new control object
+     * @see CancelWorkflowExecutionDecisionAttributes
+     */
+    public static CloseWorkflowControl cancelWorkflowControl(String details) {
+        CloseWorkflowControl control = new CloseWorkflowControl();
+        control.setDetails(details);
+
+        return control;
+    }
+
+    /**
+     * Creates control object with information for {@link DecisionType#FailWorkflowExecution} decision.
+     *
+     * @param reason  the reason for the failure
+     * @param details details of the failure, optional
+     * @return new control object
+     * @see FailWorkflowExecutionDecisionAttributes
+     */
+    public static CloseWorkflowControl failWorkflowControl(String reason, String details) {
+        CloseWorkflowControl control = new CloseWorkflowControl();
+        control.setReason(reason);
+        control.setDetails(details);
+
+        return control;
+    }
+
+    /**
+     * Creates control object with information for {@link DecisionType#CompleteWorkflowExecution} decision.
+     *
+     * @param result The result of the workflow execution
+     * @return new control object
+     * @see CompleteWorkflowExecutionDecisionAttributes
+     */
+    public static CloseWorkflowControl completeWorkflowControl(Object result) {
+        CloseWorkflowControl control = new CloseWorkflowControl();
+        control.setResult(result);
+
+        return control;
+    }
+
+    public Object getResult() {
+        return result;
+    }
+
+    public void setResult(Object result) {
+        this.result = result;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public void setDetails(String details) {
+        this.details = details;
+    }
+
+    @Override
+    public String toString() {
+        return "CloseWorkflowControl{" +
+                "result=" + result +
+                ", reason='" + reason + '\'' +
+                ", details='" + details + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CloseWorkflowControl that = (CloseWorkflowControl) o;
+        return Objects.equals(result, that.result) &&
+                Objects.equals(reason, that.reason) &&
+                Objects.equals(details, that.details);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(result, reason, details);
+    }
+}

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/handler/CloseWorkflowFailedHandlers.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/handler/CloseWorkflowFailedHandlers.java
@@ -1,0 +1,96 @@
+package com.solambda.swiffer.api.internal.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.simpleworkflow.model.CancelWorkflowExecutionFailedEventAttributes;
+import com.amazonaws.services.simpleworkflow.model.CompleteWorkflowExecutionFailedEventAttributes;
+import com.amazonaws.services.simpleworkflow.model.ContinueAsNewWorkflowExecutionFailedEventAttributes;
+import com.amazonaws.services.simpleworkflow.model.DecisionType;
+import com.amazonaws.services.simpleworkflow.model.EventType;
+import com.amazonaws.services.simpleworkflow.model.FailWorkflowExecutionFailedEventAttributes;
+import com.solambda.swiffer.api.Decisions;
+import com.solambda.swiffer.api.Marker;
+import com.solambda.swiffer.api.internal.decisions.DecisionTaskContext;
+
+/**
+ * Provides handlers for close workflow failed events.
+ * Handlers attempt to execute failed decision again with the same attributes.
+ * <p>
+ * Handles events:
+ * <ul>
+ * <li>{@link EventType#CompleteWorkflowExecutionFailed}</li>
+ * <li>{@link EventType#FailWorkflowExecutionFailed}</li>
+ * <li>{@link EventType#CancelWorkflowExecutionFailed}</li>
+ * <li>{@link EventType#ContinueAsNewWorkflowExecutionFailed}</li>
+ * </ul>
+ */
+public final class CloseWorkflowFailedHandlers {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloseWorkflowFailedHandlers.class);
+
+    /**
+     * Default handler for {@link EventType#CompleteWorkflowExecutionFailed} event.
+     *
+     * @param control  the {@link CloseWorkflowControl} containing information for {@link DecisionType#CompleteWorkflowExecution} decision that has failed
+     * @param decideTo the {@link Decisions} object
+     * @see CompleteWorkflowExecutionFailedEventAttributes
+     */
+    public void onCompleteWorkflowExecutionFailed(@Marker(CloseWorkflowControl.COMPLETE_MARKER) CloseWorkflowControl control, Decisions decideTo) {
+        LOGGER.debug("Reschedule <CompleteWorkflowExecution> decision after failure. Initial attributes: {}.", control);
+        if (control != null) {
+            decideTo.completeWorkflow(control.getResult());
+        } else {
+            LOGGER.warn("Control for previous decision not found, reschedule <CompleteWorkflowExecution> without attributes.");
+            decideTo.completeWorkflow();
+        }
+    }
+
+    /**
+     * Default handler for {@link EventType#FailWorkflowExecutionFailed} event.
+     *
+     * @param control  the {@link CloseWorkflowControl} containing information for {@link DecisionType#FailWorkflowExecution} decision that has failed
+     * @param decideTo the {@link Decisions} object
+     * @see FailWorkflowExecutionFailedEventAttributes
+     */
+    public void onFailWorkflowExecutionFailed(@Marker(CloseWorkflowControl.FAIL_MARKER) CloseWorkflowControl control, Decisions decideTo) {
+        LOGGER.debug("Reschedule <FailWorkflowExecution> decision after failure. Initial attributes: {}.", control);
+        if (control != null) {
+            decideTo.failWorkflow(control.getReason(), control.getDetails());
+        } else {
+            LOGGER.warn("Control for previous decision not found, reschedule <FailWorkflowExecution> without attributes.");
+            decideTo.failWorkflow(null, null);
+        }
+    }
+
+    /**
+     * Default handler for {@link EventType#CancelWorkflowExecutionFailed} event.
+     *
+     * @param control  the {@link CloseWorkflowControl} containing information for {@link DecisionType#CancelWorkflowExecution} decision that has failed
+     * @param decideTo the {@link Decisions} object
+     * @see CancelWorkflowExecutionFailedEventAttributes
+     */
+    public void onCancelWorkflowExecutionFailed(@Marker(CloseWorkflowControl.CANCEL_MARKER) CloseWorkflowControl control, Decisions decideTo) {
+        LOGGER.debug("Reschedule <CancelWorkflowExecution> decision after failure. Initial attributes: {}.", control);
+        if (control != null) {
+            decideTo.cancelWorkflow(control.getDetails());
+        } else {
+            LOGGER.warn("Control for previous decision not found, reschedule <CancelWorkflowExecution> without attributes.");
+            decideTo.cancelWorkflow(null);
+        }
+    }
+
+    /**
+     * Default handler for {@link EventType#ContinueAsNewWorkflowExecutionFailed} event.
+     *
+     * @param decideTo the {@link Decisions} object
+     * @param context  the failed task context
+     * @see ContinueAsNewWorkflowExecutionFailedEventAttributes
+     */
+    public void onContinueAsNewWorkflowExecutionFailed(Decisions decideTo, DecisionTaskContext context) {
+        // TODO: revisit this implementation in Issue #11
+        LOGGER.debug("Reschedule <ContinueAsNewWorkflowExecution> decision after failure. Initial attributes: {}.");
+        decideTo.continueAsNewWorkflow("1");
+    }
+
+}

--- a/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/utils/SWFUtils.java
+++ b/swiffer-api/src/main/java/com/solambda/swiffer/api/internal/utils/SWFUtils.java
@@ -1,5 +1,7 @@
 package com.solambda.swiffer.api.internal.utils;
 
+import java.util.Arrays;
+
 import com.amazonaws.services.simpleworkflow.model.WorkflowType;
 import com.google.common.base.Preconditions;
 
@@ -79,5 +81,20 @@ public class SWFUtils {
 	 */
 	public static <T> T defaultIfNull(T object, T defaultValue) {
 		return object != null ? object : defaultValue;
+	}
+
+	/**
+	 * Check if a given {@code string} starts with any of an array of specified {@code searchStrings}.
+	 *
+	 * @param string        the String to check, may be null
+	 * @param searchStrings the Strings to find, may be null or empty
+	 * @return {@code true} if the {@code string} starts with any of the the prefixes
+	 */
+	public static boolean startsWithAny(String string, String... searchStrings) {
+		if (string == null || searchStrings == null) {
+			return false;
+		}
+
+		return Arrays.stream(searchStrings).anyMatch(string::startsWith);
 	}
 }

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/DecisionExecutorImplTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/DecisionExecutorImplTest.java
@@ -1,0 +1,189 @@
+package com.solambda.swiffer.api.internal.decisions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import com.amazonaws.services.simpleworkflow.model.Decision;
+import com.amazonaws.services.simpleworkflow.model.DecisionType;
+import com.amazonaws.services.simpleworkflow.model.RespondDecisionTaskCompletedRequest;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+
+@RunWith(JUnitParamsRunner.class)
+public class DecisionExecutorImplTest {
+
+    private final AmazonSimpleWorkflow swf = mock(AmazonSimpleWorkflow.class);
+    private final DecisionExecutorImpl decisionExecutor = new DecisionExecutorImpl(swf);
+
+    private final DecisionTaskContext context = mock(DecisionTaskContext.class);
+    private final DecisionsImpl decisions = mock(DecisionsImpl.class);
+
+    @Captor
+    private ArgumentCaptor<RespondDecisionTaskCompletedRequest> requestCaptor = ArgumentCaptor.forClass(RespondDecisionTaskCompletedRequest.class);
+
+    private final List<String> compatibleWithClose = Arrays.asList(DecisionType.CancelTimer.name(),
+                                                                   DecisionType.RecordMarker.name(),
+                                                                   DecisionType.StartChildWorkflowExecution.name(),
+                                                                   DecisionType.RequestCancelExternalWorkflowExecution.name());
+
+    /**
+     * Test case: there is no close decision in the list.
+     * Expected result: all decisions should be passed to server (i.e. nothing is removed)
+     */
+    @Test
+    public void apply() throws Exception {
+        Collection<Decision> decisionList = mockAllNotCloseDecisions();
+        when(decisions.get()).thenReturn(decisionList);
+
+        decisionExecutor.apply(context, decisions);
+
+        verify(swf).respondDecisionTaskCompleted(requestCaptor.capture());
+        RespondDecisionTaskCompletedRequest actualRequest = requestCaptor.getValue();
+        assertThat(actualRequest.getDecisions()).containsOnlyElementsOf(decisionList);
+    }
+
+    /**
+     * Test case: close decisions are compatible with one another and shouldn't be filtered out.
+     */
+    @Test
+    public void apply_HasSeveralCloseDecision() throws Exception {
+        Collection<Decision> closeDecisions = mockAllCloseDecisions();
+        Collection<Decision> decisionList = new ArrayList<>(mockAllNotCloseDecisions());
+        decisionList.addAll(closeDecisions);
+
+        when(decisions.get()).thenReturn(decisionList);
+
+        decisionExecutor.apply(context, decisions);
+
+        verify(swf).respondDecisionTaskCompleted(requestCaptor.capture());
+        RespondDecisionTaskCompletedRequest actualRequest = requestCaptor.getValue();
+        Collection<String> expectedDecisions = new ArrayList<>(compatibleWithClose);
+        expectedDecisions.add(DecisionType.CancelWorkflowExecution.name());
+        expectedDecisions.add(DecisionType.CompleteWorkflowExecution.name());
+        expectedDecisions.add(DecisionType.FailWorkflowExecution.name());
+        expectedDecisions.add(DecisionType.ContinueAsNewWorkflowExecution.name());
+
+        assertThat(actualRequest.getDecisions()).extracting("decisionType").containsOnlyElementsOf(expectedDecisions);
+    }
+
+    private Object[] closeDecisions() {
+        return new Object[]{
+                mockDecision(DecisionType.CancelWorkflowExecution),
+                mockDecision(DecisionType.CompleteWorkflowExecution),
+                mockDecision(DecisionType.ContinueAsNewWorkflowExecution),
+                mockDecision(DecisionType.FailWorkflowExecution)
+        };
+    }
+
+    @Test
+    @Parameters(method = "closeDecisions")
+    public void apply_HasCloseDecision(Decision closeDecision) throws Exception {
+        Collection<Decision> decisionList = new ArrayList<>(mockAllNotCloseDecisions());
+        decisionList.add(closeDecision);
+
+        when(decisions.get()).thenReturn(decisionList);
+
+        decisionExecutor.apply(context, decisions);
+
+        verify(swf).respondDecisionTaskCompleted(requestCaptor.capture());
+        RespondDecisionTaskCompletedRequest actualRequest = requestCaptor.getValue();
+        Collection<String> expectedDecisions = new ArrayList<>(compatibleWithClose);
+        expectedDecisions.add(closeDecision.getDecisionType());
+
+        assertThat(actualRequest.getDecisions()).extracting("decisionType").containsOnlyElementsOf(expectedDecisions);
+    }
+
+    private Decision mockDecision(DecisionType type){
+        Decision decision = mock(Decision.class);
+        when(decision.getDecisionType()).thenReturn(type.name());
+
+        return decision;
+    }
+
+    private Collection<Decision> mockAllNotCloseDecisions() {
+        return Arrays.asList(mockDecision(DecisionType.ScheduleActivityTask),
+                             mockDecision(DecisionType.RequestCancelActivityTask),
+                             mockDecision(DecisionType.RecordMarker),
+                             mockDecision(DecisionType.StartTimer),
+                             mockDecision(DecisionType.CancelTimer),
+                             mockDecision(DecisionType.RequestCancelExternalWorkflowExecution),
+                             mockDecision(DecisionType.StartChildWorkflowExecution));
+    }
+
+    private Collection<Decision> mockAllCloseDecisions() {
+        return Arrays.asList(mockDecision(DecisionType.CancelWorkflowExecution),
+                             mockDecision(DecisionType.CompleteWorkflowExecution),
+                             mockDecision(DecisionType.ContinueAsNewWorkflowExecution),
+                             mockDecision(DecisionType.FailWorkflowExecution));
+    }
+
+//    @Test
+//    public void scheduleActivityTask_AfterCancel() throws Exception {
+//        Duration duration = Duration.ofHours(8);
+//        when(durationTransformer.transform(duration)).thenReturn(duration);
+//
+//        decisions.startTimer("Timer", duration)
+//                 .cancelWorkflow("Cancel")
+//                 .scheduleActivityTask(DecisionsImplTest.CustomActivity.class, "param");
+//
+//        assertThat(decisions.get()).hasSize(2);
+//        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.StartTimer.name(),
+//                                                                               DecisionType.CancelWorkflowExecution.name());
+//    }
+//
+//    @Test
+//    public void startTimer_AfterComplete() throws Exception {
+//        Duration duration = Duration.ofHours(8);
+//        when(durationTransformer.transform(duration)).thenReturn(duration);
+//
+//        decisions.scheduleActivityTask(DecisionsImplTest.CustomActivity.class, "param")
+//                 .completeWorkflow()
+//                 .startTimer("Timer", duration);
+//
+//        assertThat(decisions.get()).hasSize(2);
+//        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
+//                                                                               DecisionType.CompleteWorkflowExecution.name());
+//    }
+//
+//    @Test
+//    public void recordMarker_AfterFail() throws Exception {
+//        decisions.scheduleActivityTask(DecisionsImplTest.CustomActivity.class, "param")
+//                 .failWorkflow("Timer", "Failure")
+//                 .recordMarker("marker");
+//
+//        assertThat(decisions.get()).hasSize(2);
+//        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
+//                                                                               DecisionType.FailWorkflowExecution.name());
+//
+//    }
+//
+//    @Test
+//    public void noFinalDecisions() throws Exception {
+//        Duration duration = Duration.ofHours(8);
+//        when(durationTransformer.transform(duration)).thenReturn(duration);
+//
+//        decisions.scheduleActivityTask(DecisionsImplTest.CustomActivity.class, "param")
+//                 .recordMarker("marker")
+//                 .startTimer("Timer", duration);
+//
+//        assertThat(decisions.get()).hasSize(3);
+//        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
+//                                                                               DecisionType.RecordMarker.name(),
+//                                                                               DecisionType.StartTimer.name());
+//    }
+}

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/DecisionsImplTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/DecisionsImplTest.java
@@ -336,61 +336,6 @@ public class DecisionsImplTest {
         decisions.requestCancelExternalWorkflow("workflow", null);
     }
 
-    @Test
-    public void scheduleActivityTask_AfterCancel() throws Exception {
-        Duration duration = Duration.ofHours(8);
-        when(durationTransformer.transform(duration)).thenReturn(duration);
-
-        decisions.startTimer("Timer", duration)
-                 .cancelWorkflow("Cancel")
-                 .scheduleActivityTask(CustomActivity.class, "param");
-
-        assertThat(decisions.get()).hasSize(2);
-        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.StartTimer.name(),
-                                                                               DecisionType.CancelWorkflowExecution.name());
-    }
-
-    @Test
-    public void startTimer_AfterComplete() throws Exception {
-        Duration duration = Duration.ofHours(8);
-        when(durationTransformer.transform(duration)).thenReturn(duration);
-
-        decisions.scheduleActivityTask(CustomActivity.class, "param")
-                 .completeWorkflow()
-                 .startTimer("Timer", duration);
-
-        assertThat(decisions.get()).hasSize(2);
-        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
-                                                                               DecisionType.CompleteWorkflowExecution.name());
-    }
-
-    @Test
-    public void recordMarker_AfterFail() throws Exception {
-        decisions.scheduleActivityTask(CustomActivity.class, "param")
-                 .failWorkflow("Timer", "Failure")
-                 .recordMarker("marker");
-
-        assertThat(decisions.get()).hasSize(2);
-        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
-                                                                               DecisionType.FailWorkflowExecution.name());
-
-    }
-
-    @Test
-    public void noFinalDecisions() throws Exception {
-        Duration duration = Duration.ofHours(8);
-        when(durationTransformer.transform(duration)).thenReturn(duration);
-
-        decisions.scheduleActivityTask(CustomActivity.class, "param")
-                 .recordMarker("marker")
-                 .startTimer("Timer", duration);
-
-        assertThat(decisions.get()).hasSize(3);
-        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
-                                                                               DecisionType.RecordMarker.name(),
-                                                                               DecisionType.StartTimer.name());
-    }
-
     @ActivityType(name = "activity", version="1")
     @interface CustomActivity{}
 

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/DecisionsImplTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/DecisionsImplTest.java
@@ -336,6 +336,61 @@ public class DecisionsImplTest {
         decisions.requestCancelExternalWorkflow("workflow", null);
     }
 
+    @Test
+    public void scheduleActivityTask_AfterCancel() throws Exception {
+        Duration duration = Duration.ofHours(8);
+        when(durationTransformer.transform(duration)).thenReturn(duration);
+
+        decisions.startTimer("Timer", duration)
+                 .cancelWorkflow("Cancel")
+                 .scheduleActivityTask(CustomActivity.class, "param");
+
+        assertThat(decisions.get()).hasSize(2);
+        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.StartTimer.name(),
+                                                                               DecisionType.CancelWorkflowExecution.name());
+    }
+
+    @Test
+    public void startTimer_AfterComplete() throws Exception {
+        Duration duration = Duration.ofHours(8);
+        when(durationTransformer.transform(duration)).thenReturn(duration);
+
+        decisions.scheduleActivityTask(CustomActivity.class, "param")
+                 .completeWorkflow()
+                 .startTimer("Timer", duration);
+
+        assertThat(decisions.get()).hasSize(2);
+        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
+                                                                               DecisionType.CompleteWorkflowExecution.name());
+    }
+
+    @Test
+    public void recordMarker_AfterFail() throws Exception {
+        decisions.scheduleActivityTask(CustomActivity.class, "param")
+                 .failWorkflow("Timer", "Failure")
+                 .recordMarker("marker");
+
+        assertThat(decisions.get()).hasSize(2);
+        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
+                                                                               DecisionType.FailWorkflowExecution.name());
+
+    }
+
+    @Test
+    public void noFinalDecisions() throws Exception {
+        Duration duration = Duration.ofHours(8);
+        when(durationTransformer.transform(duration)).thenReturn(duration);
+
+        decisions.scheduleActivityTask(CustomActivity.class, "param")
+                 .recordMarker("marker")
+                 .startTimer("Timer", duration);
+
+        assertThat(decisions.get()).hasSize(3);
+        assertThat(decisions.get()).extracting("decisionType").containsExactly(DecisionType.ScheduleActivityTask.name(),
+                                                                               DecisionType.RecordMarker.name(),
+                                                                               DecisionType.StartTimer.name());
+    }
+
     @ActivityType(name = "activity", version="1")
     @interface CustomActivity{}
 

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/EventHandlerFactoryTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/EventHandlerFactoryTest.java
@@ -11,12 +11,15 @@ import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.solambda.swiffer.api.Decisions;
 import com.solambda.swiffer.api.internal.VersionedName;
 import com.solambda.swiffer.api.internal.context.ActivityTaskFailedContext;
 import com.solambda.swiffer.api.internal.context.ActivityTaskTimedOutContext;
+import com.solambda.swiffer.api.internal.handler.CloseWorkflowControl;
+import com.solambda.swiffer.api.internal.handler.CloseWorkflowFailedHandlers;
 import com.solambda.swiffer.api.mapper.DataMapper;
 import com.solambda.swiffer.api.retry.NoRetryPolicy;
 import com.solambda.swiffer.api.retry.RetryControl;
@@ -88,6 +91,51 @@ public class EventHandlerFactoryTest {
         assertThat(handler).isNotNull();
     }
 
+    @Test
+    public void createCompleteWorkflowExecutionFailedHandler() throws Exception {
+        EventHandlerFactory eventHandlerFactory = spy(new EventHandlerFactory(workflowType, dataMapper, noRetryPolicy));
+        EventHandler handler = eventHandlerFactory.createCompleteWorkflowExecutionFailedHandler();
+
+        Method expectedMethod = getCloseWorkflowHandler("onCompleteWorkflowExecutionFailed");
+        verify(eventHandlerFactory).createEventHandler(any(CloseWorkflowFailedHandlers.class),
+                                                       eq(EventHandlerFactory.COMPLETE_WORKFLOW_EXECUTION_FAILED),
+                                                       eq(expectedMethod));
+        assertThat(handler).isNotNull();
+    }
+
+    @Test
+    public void createCancelWorkflowExecutionFailedHandler() throws Exception {
+        EventHandlerFactory eventHandlerFactory = spy(new EventHandlerFactory(workflowType, dataMapper, noRetryPolicy));
+        EventHandler handler = eventHandlerFactory.createCancelWorkflowExecutionFailedHandler();
+
+        Method expectedMethod = getCloseWorkflowHandler("onCancelWorkflowExecutionFailed");
+        verify(eventHandlerFactory).createEventHandler(any(CloseWorkflowFailedHandlers.class),
+                                                       eq(EventHandlerFactory.CANCEL_WORKFLOW_EXECUTION_FAILED),
+                                                       eq(expectedMethod));
+        assertThat(handler).isNotNull();
+    }
+
+    @Test
+    public void createFailWorkflowExecutionFailedHandler() throws Exception {
+        EventHandlerFactory eventHandlerFactory = spy(new EventHandlerFactory(workflowType, dataMapper, noRetryPolicy));
+        EventHandler handler = eventHandlerFactory.createFailWorkflowExecutionFailedHandler();
+
+        Method expectedMethod = getCloseWorkflowHandler("onFailWorkflowExecutionFailed");
+        verify(eventHandlerFactory).createEventHandler(any(CloseWorkflowFailedHandlers.class),
+                                                       eq(EventHandlerFactory.FAIL_WORKFLOW_EXECUTION_FAILED),
+                                                       eq(expectedMethod));
+        assertThat(handler).isNotNull();
+    }
+
+    @Test
+    @Ignore
+    public void createContinueAsNewWorkflowExecutionFailedHandler() throws Exception {
+        EventHandlerFactory eventHandlerFactory = spy(new EventHandlerFactory(workflowType, dataMapper, noRetryPolicy));
+        EventHandler handler = eventHandlerFactory.createContinueAsNewWorkflowExecutionFailedHandler();
+        //TODO: add after issue #11 is fixed
+        fail("");
+    }
+
     private static Method getOnFailureMethod() {
         try {
             return RetryHandlers.class.getMethod("onFailure", Long.class, Decisions.class, ActivityTaskFailedContext.class);
@@ -111,6 +159,15 @@ public class EventHandlerFactoryTest {
             return RetryHandlers.class.getMethod("onTimer", RetryControl.class, Decisions.class, DecisionTaskContext.class);
         } catch (NoSuchMethodException e) {
             fail("Can't create onTimer Method", e);
+            return null;
+        }
+    }
+
+    private Method getCloseWorkflowHandler(String methodName) {
+        try {
+            return CloseWorkflowFailedHandlers.class.getMethod(methodName, CloseWorkflowControl.class, Decisions.class);
+        } catch (NoSuchMethodException e) {
+            fail("Can't get method", e);
             return null;
         }
     }

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/WorkflowTemplateImplTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/decisions/WorkflowTemplateImplTest.java
@@ -1,0 +1,115 @@
+package com.solambda.swiffer.api.internal.decisions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.amazonaws.services.simpleworkflow.model.CancelWorkflowExecutionFailedCause;
+import com.amazonaws.services.simpleworkflow.model.CompleteWorkflowExecutionFailedCause;
+import com.amazonaws.services.simpleworkflow.model.ContinueAsNewWorkflowExecutionFailedCause;
+import com.amazonaws.services.simpleworkflow.model.EventType;
+import com.amazonaws.services.simpleworkflow.model.FailWorkflowExecutionFailedCause;
+import com.solambda.swiffer.api.duration.DurationTransformer;
+import com.solambda.swiffer.api.internal.VersionedName;
+import com.solambda.swiffer.api.internal.events.EventCategory;
+import com.solambda.swiffer.api.mapper.DataMapper;
+import com.solambda.swiffer.api.retry.RetryPolicy;
+
+public class WorkflowTemplateImplTest {
+
+    private final DataMapper dataMapper = mock(DataMapper.class);
+    private final DurationTransformer durationTransformer = mock(DurationTransformer.class);
+    private final RetryPolicy globalRetryPolicy = mock(RetryPolicy.class);
+    private final EventHandlerRegistry eventHandlerRegistry = mock(EventHandlerRegistry.class);
+    private final VersionedName workflowType = mock(VersionedName.class);
+
+    private final WorkflowTemplateImpl template = new WorkflowTemplateImpl(workflowType, eventHandlerRegistry, dataMapper, durationTransformer, globalRetryPolicy);
+
+    private final DecisionTaskContext context = mock(DecisionTaskContext.class);
+
+    @Test
+    public void decide_CompleteWorkflowFailed() throws Exception {
+        String cause = CompleteWorkflowExecutionFailedCause.UNHANDLED_DECISION.name();
+        WorkflowEvent event = mock(WorkflowEvent.class);
+        when(event.category()).thenReturn(EventCategory.WORKFLOW_EXECUTION);
+        when(event.type()).thenReturn(EventType.CompleteWorkflowExecutionFailed);
+        when(event.cause()).thenReturn(cause);
+
+        List<WorkflowEvent> newEvents = Arrays.asList(event);
+        EventHandler defaultEventHandler = mock(EventHandler.class);
+
+        when(eventHandlerRegistry.getDefaultCompleteWorkflowExecutionFailedHandler(any())).thenReturn(defaultEventHandler);
+        when(context.newEvents()).thenReturn(newEvents);
+
+        template.decide(context);
+
+        verify(eventHandlerRegistry).getDefaultCompleteWorkflowExecutionFailedHandler(cause);
+        verify(defaultEventHandler).handleEvent(any(), any());
+    }
+
+    @Test
+    public void decide_CancelWorkflowFailed() throws Exception {
+        String cause = CancelWorkflowExecutionFailedCause.UNHANDLED_DECISION.name();
+        WorkflowEvent event = mock(WorkflowEvent.class);
+        when(event.category()).thenReturn(EventCategory.WORKFLOW_EXECUTION);
+        when(event.type()).thenReturn(EventType.CancelWorkflowExecutionFailed);
+        when(event.cause()).thenReturn(cause);
+
+        List<WorkflowEvent> newEvents = Arrays.asList(event);
+        EventHandler defaultEventHandler = mock(EventHandler.class);
+
+        when(eventHandlerRegistry.getDefaultCancelWorkflowExecutionFailedHandler(any())).thenReturn(defaultEventHandler);
+        when(context.newEvents()).thenReturn(newEvents);
+
+        template.decide(context);
+
+        verify(eventHandlerRegistry).getDefaultCancelWorkflowExecutionFailedHandler(cause);
+        verify(defaultEventHandler).handleEvent(any(), any());
+    }
+
+    @Test
+    public void decide_FailWorkflowFailed() throws Exception {
+        String cause = FailWorkflowExecutionFailedCause.UNHANDLED_DECISION.name();
+        WorkflowEvent event = mock(WorkflowEvent.class);
+        when(event.category()).thenReturn(EventCategory.WORKFLOW_EXECUTION);
+        when(event.type()).thenReturn(EventType.FailWorkflowExecutionFailed);
+        when(event.cause()).thenReturn(cause);
+
+        List<WorkflowEvent> newEvents = Arrays.asList(event);
+        EventHandler defaultEventHandler = mock(EventHandler.class);
+
+        when(eventHandlerRegistry.getDefaultFailWorkflowExecutionFailedHandler(any())).thenReturn(defaultEventHandler);
+        when(context.newEvents()).thenReturn(newEvents);
+
+        template.decide(context);
+
+        verify(eventHandlerRegistry).getDefaultFailWorkflowExecutionFailedHandler(cause);
+        verify(defaultEventHandler).handleEvent(any(), any());
+    }
+
+    @Test
+    public void decide_ContinueAsNewWorkflowFailed() throws Exception {
+        String cause = ContinueAsNewWorkflowExecutionFailedCause.UNHANDLED_DECISION.name();
+        WorkflowEvent event = mock(WorkflowEvent.class);
+        when(event.category()).thenReturn(EventCategory.WORKFLOW_EXECUTION);
+        when(event.type()).thenReturn(EventType.ContinueAsNewWorkflowExecutionFailed);
+        when(event.cause()).thenReturn(cause);
+
+        List<WorkflowEvent> newEvents = Arrays.asList(event);
+        EventHandler defaultEventHandler = mock(EventHandler.class);
+
+        when(eventHandlerRegistry.getDefaultContinueAsNewWorkflowExecutionFailedHandler(any())).thenReturn(defaultEventHandler);
+        when(context.newEvents()).thenReturn(newEvents);
+
+        template.decide(context);
+
+        verify(eventHandlerRegistry).getDefaultContinueAsNewWorkflowExecutionFailedHandler(cause);
+        verify(defaultEventHandler).handleEvent(any(), any());
+    }
+}

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/handler/CloseWorkflowFailedHandlersTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/handler/CloseWorkflowFailedHandlersTest.java
@@ -1,0 +1,70 @@
+package com.solambda.swiffer.api.internal.handler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import com.solambda.swiffer.api.Decisions;
+
+public class CloseWorkflowFailedHandlersTest {
+
+    private final CloseWorkflowFailedHandlers handlers = new CloseWorkflowFailedHandlers();
+
+    private Decisions decideTo = mock(Decisions.class);
+    private CloseWorkflowControl control = mock(CloseWorkflowControl.class);
+
+    @Test
+    public void onCompleteWorkflowExecutionFailed() throws Exception {
+        Object result = mock(Object.class);
+        when(control.getResult()).thenReturn(result);
+
+        handlers.onCompleteWorkflowExecutionFailed(control, decideTo);
+
+        verify(decideTo).completeWorkflow(result);
+    }
+
+    @Test
+    public void onCompleteWorkflowExecutionFailed_noControl() throws Exception {
+        handlers.onCompleteWorkflowExecutionFailed(null, decideTo);
+
+        verify(decideTo).completeWorkflow();
+    }
+
+    @Test
+    public void onFailWorkflowExecutionFailed() throws Exception {
+        String reason = "Any String";
+        String details = "Any Details";
+        when(control.getReason()).thenReturn(reason);
+        when(control.getDetails()).thenReturn(details);
+
+        handlers.onFailWorkflowExecutionFailed(control, decideTo);
+
+        verify(decideTo).failWorkflow(reason, details);
+    }
+
+    @Test
+    public void onFailWorkflowExecutionFailed_NoControl() throws Exception {
+        handlers.onFailWorkflowExecutionFailed(null, decideTo);
+
+        verify(decideTo).failWorkflow(null, null);
+    }
+
+    @Test
+    public void onCancelWorkflowExecutionFailed() throws Exception {
+        String details = "Any Details";
+        when(control.getDetails()).thenReturn(details);
+
+        handlers.onCancelWorkflowExecutionFailed(control, decideTo);
+
+        verify(decideTo).cancelWorkflow(details);
+    }
+
+    @Test
+    public void onCancelWorkflowExecutionFailed_NoControl() throws Exception {
+        handlers.onCancelWorkflowExecutionFailed(null, decideTo);
+
+        verify(decideTo).cancelWorkflow(null);
+    }
+}

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/utils/SWFUtilsTest.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/internal/utils/SWFUtilsTest.java
@@ -1,0 +1,33 @@
+package com.solambda.swiffer.api.internal.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class SWFUtilsTest {
+
+    @Test
+    public void startsWithAny() throws Exception {
+        assertThat(SWFUtils.startsWithAny("tes12345", "te", "tes", "test")).isTrue();
+    }
+
+    @Test
+    public void startsWithAny_NoPrefixesToTest() throws Exception {
+        assertThat(SWFUtils.startsWithAny("tes12345")).isFalse();
+    }
+
+    @Test
+    public void startsWithAny_NothingToTest() throws Exception {
+        assertThat(SWFUtils.startsWithAny(null)).isFalse();
+    }
+
+    @Test
+    public void startsWithAny_NoTargetToTest() throws Exception {
+        assertThat(SWFUtils.startsWithAny(null, "te", "tes", "test")).isFalse();
+    }
+
+    @Test
+    public void startsWithAny_EmptyPrefixesToTest() throws Exception {
+        assertThat(SWFUtils.startsWithAny(null, new String[]{})).isFalse();
+    }
+}

--- a/swiffer-api/src/test/java/com/solambda/swiffer/api/retry/MakeDecisionAfterCloseIT.java
+++ b/swiffer-api/src/test/java/com/solambda/swiffer/api/retry/MakeDecisionAfterCloseIT.java
@@ -1,0 +1,330 @@
+package com.solambda.swiffer.api.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.time.Duration;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflowClient;
+import com.amazonaws.services.simpleworkflow.model.AmazonSimpleWorkflowException;
+import com.amazonaws.services.simpleworkflow.model.EventType;
+import com.solambda.swiffer.api.*;
+
+/**
+ * Test workflow behaviour for the cases when activity is retried after workflow is cancelled or completed.
+ * This situation may result in two cases:
+ * <ol>
+ * <li>
+ * Validation exception by Amazon SWF;
+ * </li>
+ * <li>
+ * Decision to complete/cancel is not executed and failure event is registered.
+ * </li>
+ * </ol>
+ * The exact steps leading to one or the other case are not clear (depends on timing of the scheduled event?).
+ * <h1>Case 1</h1>
+ * <p>
+ * According to the Amazon Documentation:
+ * <blockquote>
+ * Amazon SWF checks to ensure that the decision to close or cancel the workflow execution is the last decision sent by the decider.
+ * That is, it isn't valid to have a set of decisions in which there are decisions after the one that closes the workflow.
+ * </blockquote>
+ * In this case amazon throws a {@link AmazonSimpleWorkflowException} with {@link AmazonServiceException.ErrorType#Client}
+ * and {@link AmazonServiceException#errorCode} "ValidationException" (note: the official documentation has wrong error code)
+ * and {@link AmazonServiceException#errorMessage} = "Close must be last decision in list" (or "Specified decision is incompatible with close decision").
+ * <h1>Case 2</h1>
+ * The exception is not thrown and the Workflow is not closed. In this case there are events:
+ * <ul>
+ * <li>
+ * For cancel: {@link EventType#CancelWorkflowExecutionFailed} with cause {@code UNHANDLED_DECISION}
+ * </li>
+ * <li>
+ * For complete: {@link EventType#CompleteWorkflowExecutionFailed} with cause {@code UNHANDLED_DECISION}
+ * </li>
+ * </ul>
+ * From the Amazon Documentation:
+ * <blockquote>
+ * An UnhandledDecision fault will be returned if a workflow closing decision is specified and a signal or activity
+ * event had been added to the history while the decision task was being performed by the decider.
+ * Unlike the above situations which are logic issues, this fault is always possible because of race conditions in a distributed system.
+ * </blockquote>
+ * <p>
+ * The expected behaviour to prevent both cases:
+ * <ul>
+ * <li>Make sure that decisions are not added after decision to close workflow (TBD)</li>
+ * <li>If the decision was added then decider shouldn't stop after the exceptions is received from Amazon SWF</li>
+ * </ul>
+ *
+ * @see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dg-dev-deciders.html#swf-dg-closing-workflows">Closing a Workflow Execution</a>
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#api-error-codes-table-client">Client Errors For Specific Actions</a>
+ * @see <a href="https://docs.aws.amazon.com/amazonswf/latest/apireference/API_Decision.html">UnhandledDecision fault</a>
+ */
+public class MakeDecisionAfterCloseIT {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MakeDecisionAfterCloseIT.class);
+    private static final String TASK_LIST = "MakeDecisionAfterCloseIT-task-list";
+    private static final String COMPLETE_WF_SIGNAL = "MakeDecisionAfterCloseIT-complete-wf-signal";
+    private static final String CASE1_WF_SIGNAL = "MakeDecisionAfterCloseIT-case1-wf-signal";
+    private static final RetryPolicy GLOBAL_RETRY_POLICY = new ConstantTimeRetryPolicy(Duration.ofSeconds(1));
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @WorkflowType(name = "MakeDecisionAfterCloseIT-workflow", version = "1", defaultTaskList = TASK_LIST)
+    public static @interface RetryWorkflow{}
+
+    @ActivityType(name = "MakeDecisionAfterCloseIT-failing-activity", version = "1", defaultTaskList = TASK_LIST)
+    public static @interface FailingActivity {
+    }
+
+    @ActivityType(name = "MakeDecisionAfterCloseIT-default-activity", version = "1", defaultTaskList = TASK_LIST)
+    public static @interface DefaultActivity {
+    }
+
+    @ActivityType(name = "MakeDecisionAfterCloseIT-cancel-activity", version = "1", defaultTaskList = TASK_LIST)
+    public static @interface CancelActivity {
+    }
+
+    @RetryWorkflow
+    public static class RetryWorkflowTemplate {
+
+        @OnWorkflowStarted
+        public void onStart(Decisions decideTo) {
+            decideTo.scheduleActivityTask(FailingActivity.class, "");
+        }
+
+        @OnWorkflowCancelRequested
+        public void onCancelRequested(String cause, Decisions decideTo) throws InterruptedException {
+            LOGGER.info("Cancel request received.");
+            decideTo.cancelWorkflow(cause);
+            Thread.sleep(6 * 1000);
+            LOGGER.info("Cancel workflow decision send.");
+        }
+
+        @OnSignalReceived(COMPLETE_WF_SIGNAL)
+        public void onCompleteWFSignalReceived(Decisions decideTo) throws InterruptedException {
+            LOGGER.info("Signal received.");
+            decideTo.completeWorkflow();
+            Thread.sleep(8 * 1000);
+            LOGGER.info("Complete workflow decision send.");
+        }
+
+        @OnSignalReceived(CASE1_WF_SIGNAL)
+        public void onCase1SignalReceived(Decisions decideTo) throws InterruptedException {
+            // this is intended to be mocked
+        }
+
+        @OnActivityCompleted(DefaultActivity.class)
+        public void onDefaultActivity(Decisions decideTo) throws InterruptedException {
+
+        }
+    }
+
+    public static class Executors {
+
+        @Executor(activity = FailingActivity.class)
+        public void failingActivity() throws InterruptedException {
+            throw new RuntimeException("This activity is always failing, retried by default");
+        }
+
+        @Executor(activity = DefaultActivity.class)
+        public void defaultActivity() throws InterruptedException {
+            LOGGER.info("Default activity");
+        }
+    }
+
+    private static final String DOMAIN = "github-swiffer";
+    private static Swiffer swiffer;
+
+    private static final Executors executor = spy(new Executors());
+    private static final RetryWorkflowTemplate template = spy(new RetryWorkflowTemplate());
+    private static Worker worker;
+    private static Decider decider;
+
+    private String runId;
+    private String workflowId;
+
+    @Test
+    public void retryScheduledAfterCancel() throws Exception {
+        workflowId = "retryScheduledAfterCancel";
+        runId = swiffer.startWorkflow(RetryWorkflow.class, workflowId, null);
+        sleep(Duration.ofSeconds(3));
+
+        swiffer.cancelWorkflow(workflowId, runId);
+
+        sleep(Duration.ofSeconds(20));
+        assertThat(decider.isStarted()).isTrue(); // case #1
+        waitForWorkflowToClose(5); // case #2
+    }
+
+    @Test
+    public void retryScheduledAfterComplete() throws Exception {
+        workflowId = "retryScheduledAfterComplete";
+        runId = swiffer.startWorkflow(RetryWorkflow.class, workflowId, null);
+        sleep(Duration.ofSeconds(3));
+
+        swiffer.sendSignalToWorkflow(workflowId, COMPLETE_WF_SIGNAL);
+
+        sleep(Duration.ofSeconds(10));
+        assertThat(decider.isStarted()).isTrue(); // case #1
+        waitForWorkflowToClose(5); // case #2
+    }
+
+    /**
+     * In this test the activity is scheduled after cancel. This is the definite way that leads to the case 1.
+     * <p>
+     * The tests {@link #retryScheduledAfterComplete} and {@link #retryScheduledAfterCancel()}
+     * emulate real-life situations and don't guarantee outcome (could be case 1 or case 2).
+     */
+    @Test
+    public void scheduledActivityAfterCancel() throws Exception {
+        workflowId = "case1_cancel";
+        runId = swiffer.startWorkflow(RetryWorkflow.class, workflowId, null);
+        doNothing().when(template).onStart(any());
+        doAnswer(invocation -> {
+            Decisions decideTo = (Decisions) invocation.getArguments()[0];
+            decideTo.cancelWorkflow("Cancel")
+                    .scheduleActivityTask(DefaultActivity.class, "");
+            return null;
+        }).when(template).onCase1SignalReceived(any());
+
+        sleep(Duration.ofSeconds(3));
+
+        swiffer.sendSignalToWorkflow(workflowId, CASE1_WF_SIGNAL);
+
+        waitForWorkflowToClose(10); // case #2
+        assertThat(decider.isStarted()).isTrue(); // case #1
+    }
+
+    @Test
+    public void scheduledActivityAfterFail() throws Exception {
+        workflowId = "case1_fail";
+        runId = swiffer.startWorkflow(RetryWorkflow.class, workflowId, null);
+        doNothing().when(template).onStart(any());
+        doAnswer(invocation -> {
+            Decisions decideTo = (Decisions) invocation.getArguments()[0];
+            decideTo.failWorkflow("Fail", "Deliberatly")
+                    .scheduleActivityTask(DefaultActivity.class, "");
+            return null;
+        }).when(template).onCase1SignalReceived(any());
+
+        sleep(Duration.ofSeconds(3));
+
+        swiffer.sendSignalToWorkflow(workflowId, CASE1_WF_SIGNAL);
+
+        waitForWorkflowToClose(10); // case #2
+        assertThat(decider.isStarted()).isTrue(); // case #1
+    }
+
+    @Test
+    public void scheduledActivityAfterComplete() throws Exception {
+        workflowId = "case1_complete";
+        runId = swiffer.startWorkflow(RetryWorkflow.class, workflowId, null);
+        doNothing().when(template).onStart(any());
+        doAnswer(invocation -> {
+            Decisions decideTo = (Decisions) invocation.getArguments()[0];
+            decideTo.completeWorkflow()
+                    .scheduleActivityTask(DefaultActivity.class, "");
+            return null;
+        }).when(template).onCase1SignalReceived(any());
+
+        sleep(Duration.ofSeconds(3));
+
+        swiffer.sendSignalToWorkflow(workflowId, CASE1_WF_SIGNAL);
+
+        waitForWorkflowToClose(10); // case #2
+        assertThat(decider.isStarted()).isTrue(); // case #1
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LOGGER.info("Teardown starts");
+        if (workflowId != null && runId != null) {
+            if (swiffer.isWorkflowExecutionOpen(workflowId, runId)) {
+                try {
+                    swiffer.terminateWorkflow(workflowId, runId, "Terminate running workflow at the end of the test");
+                } catch (Exception e) {
+                    LOGGER.error("Error during WF termination", e);
+                }
+            }
+        }
+
+        workflowId = null;
+        runId = null;
+
+        reset(template, executor);
+        LOGGER.info("Teardown ends");
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        AmazonSimpleWorkflow amazonSimpleWorkflow = new AmazonSimpleWorkflowClient(
+                new DefaultAWSCredentialsProviderChain())
+                .withRegion(Regions.EU_WEST_1);
+
+        swiffer = new Swiffer(amazonSimpleWorkflow, DOMAIN);
+
+        worker = swiffer.newWorkerBuilder()
+                        .taskList(TASK_LIST)
+                        .identity("worker")
+                        .executors((Object) executor)
+                        .build();
+
+        decider = swiffer.newDeciderBuilder()
+                         .taskList(TASK_LIST)
+                         .identity("decider")
+                         .workflowTemplates((Object) template)
+                         .globalRetryPolicy(GLOBAL_RETRY_POLICY)
+                         .build();
+
+        worker.start();
+        decider.start();
+    }
+
+    @AfterClass
+    public static void stopAll() {
+        try {
+            stop(decider);
+            stop(worker);
+        } catch (Exception e) {
+            LOGGER.error("Error stopping the deciders/workers", e);
+        }
+    }
+
+    private static void stop(TaskListService service) {
+        if (service != null) {
+            service.stop();
+        }
+    }
+
+    private void sleep(Duration duration) throws InterruptedException {
+        Thread.sleep(duration.toMillis());
+    }
+
+    private void waitForWorkflowToClose(int maxSeconds) throws InterruptedException {
+        long end = System.currentTimeMillis() + maxSeconds * 1000;
+        boolean started = swiffer.isWorkflowExecutionOpen(workflowId, runId);
+        while (started) {
+            if (System.currentTimeMillis() > end) {
+                fail("Workflow was not closed in the max allowed time.");
+            }
+            sleep(Duration.ofSeconds(2));
+            started = swiffer.isWorkflowExecutionOpen(workflowId, runId);
+        }
+    }
+}

--- a/swiffer-api/src/test/resources/logback-test.xml
+++ b/swiffer-api/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
 	<logger name="com.solambda.swiffer" level="debug"/>
 	<logger name="com.solambda.swiffer.api.internal.activities" level="info"/>
 	<logger name="com.solambda.swiffer.api.internal.decisions" level="info"/>
-	<logger name="com.solambda.swiffer.api.internal.decisions" level="info"/>
+	<logger name="com.solambda.swiffer.api.internal.decisions" level="debug"/>
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />


### PR DESCRIPTION
Prevent failure if new decisions are added after the close:
1) do not add new decisions into the list if one of the close decisions was added (complete/cancel/fail workflow);
2) catch validation exception thrown by Amazon SWF if such decisions was added somehow (despite 1).